### PR TITLE
feat: GHA-0003 initial release

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -45,7 +45,7 @@ runs:
       env:
         LOG_LEVEL: DEBUG
       with:
-        directory: ${{ inputs.terraform-dir }}
+        directory: ${{ gihub.workspace }}/${{ inputs.terraform-dir }}
         tag_groups: git
         output_format: json
 

--- a/action.yaml
+++ b/action.yaml
@@ -45,49 +45,14 @@ runs:
       env:
         LOG_LEVEL: DEBUG
       with:
-        version: 0.1.129
-        directory: ${ inputs.terraform-dir }
-        skip_directory: test
-        tag: git_modifiers,git_commit,git_repository,yor_trace
-        tag_groups: git,code2cloud
+        directory: ${{ github.workspace }}/${{ inputs.terraform-dir }}
+        # skip_directory: test
+        # skip_tags: git_modifiers,git_commit,git_repository
+        tag_groups: git
         # custom_tags: path/to/plugin.so
         output_format: json
 
-    # - name: Run Yor tagging
-    #   shell: bash
-    #   run: |
-    #     echo "Tagging Terraform files in ${{ inputs.terraform-dir }}..."
-    #     yor tag -d "${{ inputs.terraform-dir }}"
+    - name: Commit tag changes
+      if: ${{ inputs.commit-changes == 'true' }}
+      uses: stefanzweifel/git-auto-commit-action@v4
 
-    # - name: Show git diff after tagging
-    #   shell: bash
-    #   run: |
-    #     echo "Modified files:"
-    #     git --no-pager diff --name-only "${{ inputs.terraform-dir }}"
-    #     echo "----"
-    #     git --no-pager diff "${{ inputs.terraform-dir }}"
-
-    # - name: Write Summary of Modified Files
-    #   shell: bash
-    #   run: |
-    #     {
-    #       echo "### 🏷️ Yor Git Metadata Tags Summary"
-    #       echo ""
-    #       echo "**Modified files:**"
-    #       git diff --name-only "${{ inputs.terraform-dir }}" | sed 's/^/- /'
-    #     } >> $GITHUB_STEP_SUMMARY
-
-    # - name: Commit Yor tags
-    #   if: ${{ inputs.commit-changes == 'true' }}
-    #   shell: bash
-    #   run: |
-    #     if [[ "$GITHUB_EVENT_NAME" == "pull_request" || "$GITHUB_REPOSITORY" == *"/fork" ]]; then
-    #       echo "Skipping commit on pull request or fork"
-    #       exit 0
-    #     fi
-
-    #     git config user.name "github-actions"
-    #     git config user.email "github-actions@github.com"
-    #     git add "${{ inputs.terraform-dir }}"
-    #     git commit -m "chore: add Yor Git metadata tags" || echo "No changes to commit"
-    #     git push

--- a/action.yaml
+++ b/action.yaml
@@ -1,44 +1,88 @@
-name: 'Action Name'
-description: 'Action Description'
+name: "Yor Git Metadata Tagging"
+description: "Composite action to tag Terraform files with Yor Git metadata and optionally commit them."
 
 inputs:
-  input-1:
-    description: Input description.
+  terraform-dir:
+    description: "Relative path to the directory containing Terraform configuration files (e.g., 'tf', 'infrastructure')."
     required: false
-    default: default-value
-  input-2:
-    description: Input description.
+    type: string
+    default: "tf"
+
+  release-tag:
+    description: "Git release tag to check out. If omitted, the latest commit on the default branch is used."
     required: false
-    default: default-value
-  input-3:
-    description: Input description.
+    type: string
+    default: ""
+
+  commit-changes:
+    description: "Whether to commit tagged files. Accepts 'true' or 'false'."
     required: false
-    default: default-value
-  github-token:
-    description: 'GitHub token'
-    required: true
+    type: boolean
+    default: true
 
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: 3.x
-
-    - name: Sample step to call GitHub API
+    - name: Set Checkout Ref
+      id: set-ref
       shell: bash
-      env:
-        GITHUB_TOKEN: ${{ inputs.github-token }}
       run: |
-        ISSUE_NUMBER="${{ github.event.issue.number }}"
-        REPO="${{ github.repository }}"
-        OWNER=$(echo $REPO | cut -d'/' -f1)
-        BRANCH_NAME="${{ steps.create-branch.outputs.branch-name }}"
-        COMMENT_BODY="Branch [$BRANCH_NAME](https://github.com/$OWNER/$REPO/tree/$BRANCH_NAME) created 🚀"
+        if [[ -n "${{ inputs.release-tag }}" ]]; then
+          echo "ref=${{ inputs.release-tag }}" >> $GITHUB_OUTPUT
+        else
+          echo "ref=${GITHUB_REF_NAME}" >> $GITHUB_OUTPUT
+        fi
 
-        curl -s -X POST \
-          -H "Authorization: token $GITHUB_TOKEN" \
-          -H "Content-Type: application/json" \
-          -d "{\"body\": \"$COMMENT_BODY\"}" \
-          https://api.github.com/repos/$REPO/issues/$ISSUE_NUMBER/comments
+    - name: Checkout Repo
+      id: checkout
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ steps.set-ref.outputs.ref }}
+        fetch-depth: 0
+
+    - name: Set up Yor
+      shell: bash
+      run: |
+        curl -Lo yor.tar.gz https://github.com/bridgecrewio/yor/releases/latest/download/yor_$(uname -s)_$(uname -m).tar.gz
+        mkdir -p yor-bin
+        tar -xzf yor.tar.gz -C yor-bin
+        echo "$PWD/yor-bin" >> $GITHUB_PATH
+
+    - name: Run Yor tagging
+      shell: bash
+      run: |
+        echo "Tagging Terraform files in ${{ inputs.terraform-dir }}..."
+        yor tag -d "${{ inputs.terraform-dir }}"
+
+    - name: Show git diff after tagging
+      shell: bash
+      run: |
+        echo "Modified files:"
+        git --no-pager diff --name-only "${{ inputs.terraform-dir }}"
+        echo "----"
+        git --no-pager diff "${{ inputs.terraform-dir }}"
+
+    - name: Write Summary of Modified Files
+      shell: bash
+      run: |
+        {
+          echo "### 🏷️ Yor Git Metadata Tags Summary"
+          echo ""
+          echo "**Modified files:**"
+          git diff --name-only "${{ inputs.terraform-dir }}" | sed 's/^/- /'
+        } >> $GITHUB_STEP_SUMMARY
+
+    - name: Commit Yor tags
+      if: ${{ inputs.commit-changes == 'true' }}
+      shell: bash
+      run: |
+        if [[ "$GITHUB_EVENT_NAME" == "pull_request" || "$GITHUB_REPOSITORY" == *"/fork" ]]; then
+          echo "Skipping commit on pull request or fork"
+          exit 0
+        fi
+
+        git config user.name "github-actions"
+        git config user.email "github-actions@github.com"
+        git add "${{ inputs.terraform-dir }}"
+        git commit -m "chore: add Yor Git metadata tags" || echo "No changes to commit"
+        git push

--- a/action.yaml
+++ b/action.yaml
@@ -45,7 +45,7 @@ runs:
       env:
         LOG_LEVEL: DEBUG
       with:
-        directory: ${{ github.workspace }}/${{ inputs.terraform-dir }}
+        directory: ${{ github.workspace }}/${{ inputs.terraform-dir }} 
         # skip_directory: test
         # skip_tags: git_modifiers,git_commit,git_repository
         tag_groups: git

--- a/action.yaml
+++ b/action.yaml
@@ -45,11 +45,8 @@ runs:
       env:
         LOG_LEVEL: DEBUG
       with:
-        directory: ${{ github.workspace }}/${{ inputs.terraform-dir }} 
-        # skip_directory: test
-        # skip_tags: git_modifiers,git_commit,git_repository
+        directory: ${{ github.workspace }}/{{ inputs.terraform-dir }}
         tag_groups: git
-        # custom_tags: path/to/plugin.so
         output_format: json
 
     - name: Commit tag changes

--- a/action.yaml
+++ b/action.yaml
@@ -45,7 +45,7 @@ runs:
       env:
         LOG_LEVEL: DEBUG
       with:
-        directory: ${{ gihub.workspace }}/${{ inputs.terraform-dir }}
+        directory: ${{ github.workspace }}/${{ inputs.terraform-dir }}
         tag_groups: git
         output_format: json
 

--- a/action.yaml
+++ b/action.yaml
@@ -43,15 +43,18 @@ runs:
     - name: Set up Yor
       shell: bash
       run: |
-        YOR_VERSION="0.1.215"
-        YOR_OS=$(uname -s | tr '[:upper:]' '[:lower:]')
-        YOR_ARCH=$(uname -m)
-        if [[ "$YOR_ARCH" == "x86_64" ]]; then YOR_ARCH="amd64"; fi
+        YOR_VERSION="0.1.200"
+        OS=$(uname -s | tr '[:upper:]' '[:lower:]')  # linux or darwin
+        ARCH=$(uname -m)
+        if [[ "$ARCH" == "x86_64" ]]; then ARCH="amd64"; fi
+        if [[ "$ARCH" == "arm64"* ]] || [[ "$ARCH" == "aarch64"* ]]; then ARCH="arm64"; fi
 
-        curl -Lo yor.tar.gz "https://github.com/bridgecrewio/yor/releases/download/v${YOR_VERSION}/yor_${YOR_VERSION}_${YOR_OS}_${YOR_ARCH}.tar.gz"
-        mkdir -p yor-bin
+        URL="https://github.com/bridgecrewio/yor/releases/download/v$YOR_VERSION/yor_${YOR_VERSION}_${OS}_${ARCH}.tar.gz"
+        echo "Downloading Yor from: $URL"
+        curl -sfL "$URL" -o yor.tar.gz
         tar -xzf yor.tar.gz -C yor-bin
         echo "$PWD/yor-bin" >> $GITHUB_PATH
+
 
     - name: Run Yor tagging
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -40,57 +40,54 @@ runs:
         ref: ${{ steps.set-ref.outputs.ref }}
         fetch-depth: 0
 
-    - name: Set up Yor
-      shell: bash
-      run: |
-        YOR_VERSION="0.1.200"
-        OS=$(uname -s | tr '[:upper:]' '[:lower:]')  # linux or darwin
-        ARCH=$(uname -m)
-        if [[ "$ARCH" == "x86_64" ]]; then ARCH="amd64"; fi
-        if [[ "$ARCH" == "arm64"* ]] || [[ "$ARCH" == "aarch64"* ]]; then ARCH="arm64"; fi
+    - name: Run yor action
+      uses: bridgecrewio/yor-action@main
+      env:
+        LOG_LEVEL: DEBUG
+      with:
+        version: 0.1.129
+        directory: ${ inputs.terraform-dir }
+        skip_directory: test
+        tag: git_modifiers,git_commit,git_repository,yor_trace
+        tag_groups: git,code2cloud
+        # custom_tags: path/to/plugin.so
+        output_format: json
 
-        URL="https://github.com/bridgecrewio/yor/releases/download/v$YOR_VERSION/yor_${YOR_VERSION}_${OS}_${ARCH}.tar.gz"
-        echo "Downloading Yor from: $URL"
-        curl -sfL "$URL" -o yor.tar.gz
-        tar -xzf yor.tar.gz -C yor-bin
-        echo "$PWD/yor-bin" >> $GITHUB_PATH
+    # - name: Run Yor tagging
+    #   shell: bash
+    #   run: |
+    #     echo "Tagging Terraform files in ${{ inputs.terraform-dir }}..."
+    #     yor tag -d "${{ inputs.terraform-dir }}"
 
+    # - name: Show git diff after tagging
+    #   shell: bash
+    #   run: |
+    #     echo "Modified files:"
+    #     git --no-pager diff --name-only "${{ inputs.terraform-dir }}"
+    #     echo "----"
+    #     git --no-pager diff "${{ inputs.terraform-dir }}"
 
-    - name: Run Yor tagging
-      shell: bash
-      run: |
-        echo "Tagging Terraform files in ${{ inputs.terraform-dir }}..."
-        yor tag -d "${{ inputs.terraform-dir }}"
+    # - name: Write Summary of Modified Files
+    #   shell: bash
+    #   run: |
+    #     {
+    #       echo "### 🏷️ Yor Git Metadata Tags Summary"
+    #       echo ""
+    #       echo "**Modified files:**"
+    #       git diff --name-only "${{ inputs.terraform-dir }}" | sed 's/^/- /'
+    #     } >> $GITHUB_STEP_SUMMARY
 
-    - name: Show git diff after tagging
-      shell: bash
-      run: |
-        echo "Modified files:"
-        git --no-pager diff --name-only "${{ inputs.terraform-dir }}"
-        echo "----"
-        git --no-pager diff "${{ inputs.terraform-dir }}"
+    # - name: Commit Yor tags
+    #   if: ${{ inputs.commit-changes == 'true' }}
+    #   shell: bash
+    #   run: |
+    #     if [[ "$GITHUB_EVENT_NAME" == "pull_request" || "$GITHUB_REPOSITORY" == *"/fork" ]]; then
+    #       echo "Skipping commit on pull request or fork"
+    #       exit 0
+    #     fi
 
-    - name: Write Summary of Modified Files
-      shell: bash
-      run: |
-        {
-          echo "### 🏷️ Yor Git Metadata Tags Summary"
-          echo ""
-          echo "**Modified files:**"
-          git diff --name-only "${{ inputs.terraform-dir }}" | sed 's/^/- /'
-        } >> $GITHUB_STEP_SUMMARY
-
-    - name: Commit Yor tags
-      if: ${{ inputs.commit-changes == 'true' }}
-      shell: bash
-      run: |
-        if [[ "$GITHUB_EVENT_NAME" == "pull_request" || "$GITHUB_REPOSITORY" == *"/fork" ]]; then
-          echo "Skipping commit on pull request or fork"
-          exit 0
-        fi
-
-        git config user.name "github-actions"
-        git config user.email "github-actions@github.com"
-        git add "${{ inputs.terraform-dir }}"
-        git commit -m "chore: add Yor Git metadata tags" || echo "No changes to commit"
-        git push
+    #     git config user.name "github-actions"
+    #     git config user.email "github-actions@github.com"
+    #     git add "${{ inputs.terraform-dir }}"
+    #     git commit -m "chore: add Yor Git metadata tags" || echo "No changes to commit"
+    #     git push

--- a/action.yaml
+++ b/action.yaml
@@ -45,7 +45,7 @@ runs:
       env:
         LOG_LEVEL: DEBUG
       with:
-        directory: ${{ github.workspace }}/{{ inputs.terraform-dir }}
+        directory: "${{ github.workspace }}/${{ inputs.terraform-dir }}"
         tag_groups: git
         output_format: json
 

--- a/action.yaml
+++ b/action.yaml
@@ -45,7 +45,7 @@ runs:
       env:
         LOG_LEVEL: DEBUG
       with:
-        directory: "${{ github.workspace }}/${{ inputs.terraform-dir }}"
+        directory: ${{ inputs.terraform-dir }}
         tag_groups: git
         output_format: json
 

--- a/action.yaml
+++ b/action.yaml
@@ -43,7 +43,12 @@ runs:
     - name: Set up Yor
       shell: bash
       run: |
-        curl -Lo yor.tar.gz https://github.com/bridgecrewio/yor/releases/latest/download/yor_$(uname -s)_$(uname -m).tar.gz
+        YOR_VERSION="0.1.215"
+        YOR_OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+        YOR_ARCH=$(uname -m)
+        if [[ "$YOR_ARCH" == "x86_64" ]]; then YOR_ARCH="amd64"; fi
+
+        curl -Lo yor.tar.gz "https://github.com/bridgecrewio/yor/releases/download/v${YOR_VERSION}/yor_${YOR_VERSION}_${YOR_OS}_${YOR_ARCH}.tar.gz"
         mkdir -p yor-bin
         tar -xzf yor.tar.gz -C yor-bin
         echo "$PWD/yor-bin" >> $GITHUB_PATH


### PR DESCRIPTION
This pull request updates the `action.yaml` file to introduce a new composite GitHub Action for tagging Terraform files with Yor Git metadata and optionally committing the changes. The changes include renaming the action, modifying inputs to align with its functionality, and restructuring the workflow steps.

### Updates to Action Metadata and Inputs:

* **Action Name and Description:** Renamed the action to "Yor Git Metadata Tagging" and updated the description to reflect its purpose of tagging Terraform files and optionally committing them.
* **Inputs:** Added new inputs (`terraform-dir`, `release-tag`, `commit-changes`) with detailed descriptions and default values to support the functionality of the action. Removed unused inputs (`input-1`, `input-2`, `input-3`, `github-token`).

### Workflow Steps:

* **Checkout Repository:** Added a step to set the Git reference (`release-tag` or default branch) and checkout the repository using `actions/checkout`.
* **Run Yor Action:** Integrated the Yor tagging action (`bridgecrewio/yor-action`) to tag Terraform files with Git metadata, specifying the directory and tag groups.
* **Commit Changes:** Added an optional step to commit tagged files using `stefanzweifel/git-auto-commit-action` if `commit-changes` is set to `true`.